### PR TITLE
Only increment module.time when part is tracked

### DIFF
--- a/timeModule.lua
+++ b/timeModule.lua
@@ -33,7 +33,7 @@ function module:Update(dt)
 	
 	if module.reverse then
 		module.time -= module.speed
-	else
+	elseif #module.tracking > 0 then
 		module.time += module.speed
 	end
 	


### PR DESCRIPTION
This will allow the script to instantly unanchor the parts instead of doing it after a delay